### PR TITLE
Fixed event

### DIFF
--- a/com/mintyplays/tutorial/event/events/EventSendPacket.java
+++ b/com/mintyplays/tutorial/event/events/EventSendPacket.java
@@ -7,7 +7,7 @@ public class EventSendPacket extends Event {
     private Packet packet;
 
     public EventSendPacket(Packet packet) {
-        packet = null;
+        this.packet = null;
         setPacket(packet);
     }
 


### PR DESCRIPTION
Fixed the event, so `getPacket()` will not return null.